### PR TITLE
make 'Mod + z/x' more relevant to the current focused window

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -273,6 +273,20 @@ void FullRemoveNode(HWND hwnd)
     RemoveNode(hwnd, tag);
 }
 
+node* FindNodeInChain(node* head, int idx)
+{
+    node* nd = head;
+	int i = 0;
+
+    if (!head) return NULL;
+
+    for (; i < idx && nd; i++) {
+        nd = (node*)nd->next;
+    }
+
+    return nd;
+}
+
 void SwapWindowWithNode(node *window)
 {
 
@@ -283,6 +297,19 @@ void SwapWindowWithNode(node *window)
     tags[current_tag].current_window->hwnd = temp;
     tags[current_tag].current_window = window;
   }
+}
+
+void SwapWindowWithFirstNonMasterWindow()
+{
+    node* head = tags[current_tag].nodes;
+    node* current = tags[current_tag].current_window;
+    int sub_node_idx = tags[current_tag].masterarea_count;
+
+    if (current != head)
+    {
+        node* nd = FindNodeInChain(head, sub_node_idx);
+        SwapWindowWithNode(nd);
+    }
 }
 
 void FocusCurrent()
@@ -408,6 +435,7 @@ void ArrangeWindows()
               height = (screen_height / 2) + margin;
             } else {
               // Normal windows to be tiled
+
               x = (screen_width / ((a + 1) - masterarea_count)) * (a - i);
               y = (screen_height / 2) + margin;
               width = (screen_width / ((a + 1) - masterarea_count));
@@ -677,6 +705,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
           break;
 
         case KEY_INC_AREA:
+          SwapWindowWithFirstNonMasterWindow();
           tags[current_tag].masterarea_count++;
           ArrangeWindows();
           break;


### PR DESCRIPTION
Hi Zane,

Since I knew there's a popular concept in the Linux world named "Tiling Window Manager" I've been deeply drawn into it. And from then I've been looking for such one on windows (freeware & opensource ). 

And I find yours. It's awesome ! I've been using it for a couple of days. It's nice and I really like your work! Thank you!

Only one thing that I'm a little not satisfied with is, when using "Mod + z/x" to increase a second master window, it just directly takes one form the queue. It doesn't help too much in reality, because the first available window in the queue is often not what I'm interested to turn to the second major window. 

What I think is more attractive is, it would be nicer if the current focused window (when it's not in the master areas) will turn to the 2nd major window. And the next focused one becomes 3rd, and in turn.

How do you think about that ?

I made a branch in my repo and have finished this idea. I've tested it locally, and works perfectly. And I want to merge this feature into your work. Could you consider to accept it ?

Thank you !
lookof